### PR TITLE
use @id everywhere

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,12 +7,12 @@ const io = require('socket.io')(http);
 const {startPolling} = require('./src/lib/api');
 
 const STATION = {
-  URI: 'http://irail.be/stations/NMBS/008892007',
+  '@id': 'http://irail.be/stations/NMBS/008892007',
   name: 'Gent Sint-Pieters'
 }; // can't import from constants because that's an es6 export
 
 
-startPolling(io, {stop: STATION.URI});
+startPolling(io, {stop: STATION['@id']});
 
 app.set('port', (process.env.PORT || 3001));
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,7 @@ export const times = {
 };
 
 export const STATION = {
-  URI: 'http://irail.be/stations/NMBS/008892007',
+  '@id': 'http://irail.be/stations/NMBS/008892007',
   name: 'Gent-Sint-Pieters',
   longitude: 3.710675,
   latitude: 51.035896

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -13,8 +13,8 @@ export const receiveQueries = (queries) => ({
 export const listenToQueries = () => (
   dispatch => {
     const socket = io(API_BASE_URI);
-    // socket.emit('fetchLogs', { stop: STATION.URI});
-    socket.on(STATION.URI, (queries) => {
+    // socket.emit('fetchLogs', { stop: STATION['@id']});
+    socket.on(STATION['@id'], (queries) => {
       dispatch(receiveQueries(queries));
     });
   }


### PR DESCRIPTION
it doesn't make sense to configure the settings in a different method than the stops you get from the API.

later change would be that the STATION in constants.js should move to somewhere that's consumeable by commonJS and es6